### PR TITLE
Remove goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,0 @@
----
-project_name: pathlib
-release:
-   prerelease: auto

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,3 @@ go:
 
 script:
     - go test -v -cover ./...
-    - curl -sfL https://git.io/goreleaser | sh -s -- check # check goreleaser config for deprecations
-
-deploy:
-- provider: script
-  script: curl -sL https://git.io/goreleaser | bash
-  on:
-    tags: true
-    condition: $TRAVIS_OS_NAME = linux
-    go: 1.14.x


### PR DESCRIPTION
Honestly, goreleaser isn't really needed if we're not distrubting any
binaries. The only convenience it provides is adding github releases.