### PR TITLE
Adding pathlib.File

### DIFF
--- a/file.go
+++ b/file.go
@@ -1,0 +1,9 @@
+package pathlib
+
+import "github.com/spf13/afero"
+
+// File represents a file in the filesystem. It inherits the afero.File interface
+// but might also include additional functionality.
+type File struct {
+	afero.File
+}


### PR DESCRIPTION
`pathlib.File` is meant to be a thin wrapper around `afero.File`. The philosophy behind doing this is that we can extend the API further if we want to. Originally I had `Open()` and `OpenFile()` returning an `afero.File` but I think this limits the API too much.