### PR TITLE
Breaking out stat into separate functions

### DIFF
--- a/path.go
+++ b/path.go
@@ -188,6 +188,12 @@ func (p *Path) IsDir() (bool, error) {
 	return afero.IsDir(p.Fs(), p.Path())
 }
 
+// IsDir returns whether or not the os.FileInfo object represents a
+// directory.
+func IsDir(fileInfo os.FileInfo) bool {
+	return fileInfo.IsDir()
+}
+
 // IsEmpty checks if a given file or directory is empty.
 func (p *Path) IsEmpty() (bool, error) {
 	return afero.IsEmpty(p.Fs(), p.Path())

--- a/path.go
+++ b/path.go
@@ -545,3 +545,19 @@ func (p *Path) Mtime() (time.Time, error) {
 func Mtime(fileInfo os.FileInfo) (time.Time, error) {
 	return fileInfo.ModTime(), nil
 }
+
+// Size returns the size of the object. Fails if the object doesn't exist.
+func (p *Path) Size() (int64, error) {
+	stat, err := p.Stat()
+	if err != nil {
+		return 0, err
+	}
+	return Size(stat), nil
+}
+
+// Size returns the size described by the os.FileInfo. Before you say anything,
+// yes... you could just do fileInfo.Size(). This is purely a convenience function
+// to create API consistency.
+func Size(fileInfo os.FileInfo) int64 {
+	return fileInfo.Size()
+}

--- a/path_test.go
+++ b/path_test.go
@@ -135,6 +135,39 @@ func (p *PathSuite) TestRenamePath() {
 	assert.False(p.T(), oldFileExists)
 }
 
+func (p *PathSuite) TestSizeZero() {
+	file := p.tmpdir.Join("file.txt")
+	require.NoError(p.T(), file.WriteFile([]byte{}, 0o644))
+	size, err := file.Size()
+	require.NoError(p.T(), err)
+	p.Zero(size)
+}
+
+func (p *PathSuite) TestSizeNonZero() {
+	msg := "oh, it's you"
+	file := p.tmpdir.Join("file.txt")
+	require.NoError(p.T(), file.WriteFile([]byte(msg), 0o644))
+	size, err := file.Size()
+	require.NoError(p.T(), err)
+	p.Equal(len(msg), int(size))
+}
+
+func (p *PathSuite) TestIsDir() {
+	dir := p.tmpdir.Join("dir")
+	require.NoError(p.T(), dir.Mkdir(0o755))
+	isDir, err := dir.IsDir()
+	require.NoError(p.T(), err)
+	p.True(isDir)
+}
+
+func (p *PathSuite) TestIsntDir() {
+	file := p.tmpdir.Join("file.txt")
+	require.NoError(p.T(), file.WriteFile([]byte("hello world!"), 0o644))
+	isDir, err := file.IsDir()
+	require.NoError(p.T(), err)
+	p.False(isDir)
+}
+
 func (p *PathSuite) TestGetLatest() {
 	now := time.Now()
 	for i := 0; i < 5; i++ {


### PR DESCRIPTION
This fixes #13.

We break out the IsSymlink/IsFile calls into standalone functions so that
users may be able to reuse calls to Stat/Lstat.