### PR TITLE
Changing how default modes work

### DIFF
--- a/path.go
+++ b/path.go
@@ -19,6 +19,8 @@ type Path struct {
 	// DefaultFileMode is the mode that is used when creating new files in functions
 	// that do not accept os.FileMode as a parameter.
 	DefaultFileMode os.FileMode
+	// DefaultDirMode is the mode that will be used when creating new directories
+	DefaultDirMode os.FileMode
 	// Sep is the seperator used in path calculations. By default this is set to
 	// os.PathSeparator.
 	Sep string
@@ -34,7 +36,8 @@ func NewPathAfero(path string, fs afero.Fs) *Path {
 	return &Path{
 		path:            path,
 		fs:              fs,
-		DefaultFileMode: 0o644,
+		DefaultFileMode: DefaultFileMode,
+		DefaultDirMode:  DefaultDirMode,
 		Sep:             string(os.PathSeparator),
 	}
 }
@@ -98,12 +101,23 @@ func (p *Path) Create() (File, error) {
 
 // Mkdir makes the current dir. If the parents don't exist, an error
 // is returned.
-func (p *Path) Mkdir(perm os.FileMode) error {
+func (p *Path) Mkdir() error {
+	return p.Fs().Mkdir(p.String(), p.DefaultDirMode)
+}
+
+// MkdirMode makes the current dir. If the parents don't exist, an error
+// is returned.
+func (p *Path) MkdirMode(perm os.FileMode) error {
 	return p.Fs().Mkdir(p.String(), perm)
 }
 
 // MkdirAll makes all of the directories up to, and including, the given path.
-func (p *Path) MkdirAll(perm os.FileMode) error {
+func (p *Path) MkdirAll() error {
+	return p.Fs().MkdirAll(p.String(), p.DefaultDirMode)
+}
+
+// MkdirAllMode makes all of the directories up to, and including, the given path.
+func (p *Path) MkdirAllMode(perm os.FileMode) error {
 	return p.Fs().MkdirAll(p.String(), perm)
 }
 

--- a/path_test.go
+++ b/path_test.go
@@ -85,7 +85,7 @@ func (p *PathSuite) TestChmod() {
 
 func (p *PathSuite) TestMkdir() {
 	subdir := p.tmpdir.Join("subdir")
-	assert.NoError(p.T(), subdir.Mkdir(0o777))
+	assert.NoError(p.T(), subdir.Mkdir())
 	isDir, err := subdir.IsDir()
 	require.NoError(p.T(), err)
 	assert.True(p.T(), isDir)
@@ -93,12 +93,12 @@ func (p *PathSuite) TestMkdir() {
 
 func (p *PathSuite) TestMkdirParentsDontExist() {
 	subdir := p.tmpdir.Join("subdir1", "subdir2")
-	assert.Error(p.T(), subdir.Mkdir(0o777))
+	assert.Error(p.T(), subdir.Mkdir())
 }
 
 func (p *PathSuite) TestMkdirAll() {
 	subdir := p.tmpdir.Join("subdir")
-	assert.NoError(p.T(), subdir.MkdirAll(0o777))
+	assert.NoError(p.T(), subdir.MkdirAll())
 	isDir, err := subdir.IsDir()
 	require.NoError(p.T(), err)
 	assert.True(p.T(), isDir)
@@ -106,7 +106,7 @@ func (p *PathSuite) TestMkdirAll() {
 
 func (p *PathSuite) TestMkdirAllMultipleSubdirs() {
 	subdir := p.tmpdir.Join("subdir1", "subdir2", "subdir3")
-	assert.NoError(p.T(), subdir.MkdirAll(0o777))
+	assert.NoError(p.T(), subdir.MkdirAll())
 	isDir, err := subdir.IsDir()
 	require.NoError(p.T(), err)
 	assert.True(p.T(), isDir)
@@ -154,7 +154,7 @@ func (p *PathSuite) TestSizeNonZero() {
 
 func (p *PathSuite) TestIsDir() {
 	dir := p.tmpdir.Join("dir")
-	require.NoError(p.T(), dir.Mkdir(0o755))
+	require.NoError(p.T(), dir.Mkdir())
 	isDir, err := dir.IsDir()
 	require.NoError(p.T(), err)
 	p.True(isDir)
@@ -225,7 +225,7 @@ func (p *PathSuite) TestDirExists() {
 	require.NoError(p.T(), err)
 	p.False(exists)
 
-	require.NoError(p.T(), dir1.Mkdir(0o755))
+	require.NoError(p.T(), dir1.Mkdir())
 	exists, err = dir1.DirExists()
 	require.NoError(p.T(), err)
 	p.True(exists)
@@ -265,8 +265,8 @@ func (p *PathSuite) TestIsSymlink() {
 }
 
 func (p *PathSuite) TestResolveAll() {
-	require.NoError(p.T(), p.tmpdir.Join("mnt", "nfs", "data", "users", "home", "LandonTClipp").MkdirAll(0o755))
-	require.NoError(p.T(), p.tmpdir.Join("mnt", "nfs", "symlinks").MkdirAll(0o755))
+	require.NoError(p.T(), p.tmpdir.Join("mnt", "nfs", "data", "users", "home", "LandonTClipp").MkdirAll())
+	require.NoError(p.T(), p.tmpdir.Join("mnt", "nfs", "symlinks").MkdirAll())
 	require.NoError(p.T(), p.tmpdir.Join("mnt", "nfs", "symlinks", "home").Symlink(NewPath("../data/users/home")))
 	require.NoError(p.T(), p.tmpdir.Join("home").Symlink(NewPath("./mnt/nfs/symlinks/home")))
 
@@ -277,8 +277,8 @@ func (p *PathSuite) TestResolveAll() {
 }
 
 func (p *PathSuite) TestResolveAllAbsolute() {
-	require.NoError(p.T(), p.tmpdir.Join("mnt", "nfs", "data", "users", "home", "LandonTClipp").MkdirAll(0o755))
-	require.NoError(p.T(), p.tmpdir.Join("mnt", "nfs", "symlinks").MkdirAll(0o755))
+	require.NoError(p.T(), p.tmpdir.Join("mnt", "nfs", "data", "users", "home", "LandonTClipp").MkdirAll())
+	require.NoError(p.T(), p.tmpdir.Join("mnt", "nfs", "symlinks").MkdirAll())
 	require.NoError(p.T(), p.tmpdir.Join("mnt", "nfs", "symlinks", "home").Symlink(p.tmpdir.Join("mnt", "nfs", "data", "users", "home")))
 	require.NoError(p.T(), p.tmpdir.Join("home").Symlink(NewPath("./mnt/nfs/symlinks/home")))
 
@@ -294,9 +294,9 @@ func (p *PathSuite) TestResolveAllAbsolute() {
 
 func (p *PathSuite) TestEquals() {
 	hello1 := p.tmpdir.Join("hello", "world")
-	require.NoError(p.T(), hello1.MkdirAll(0o755))
+	require.NoError(p.T(), hello1.MkdirAll())
 	hello2 := p.tmpdir.Join("hello", "world")
-	require.NoError(p.T(), hello2.MkdirAll(0o755))
+	require.NoError(p.T(), hello2.MkdirAll())
 
 	p.True(hello1.Equals(hello2))
 }

--- a/scenarios_test.go
+++ b/scenarios_test.go
@@ -31,7 +31,7 @@ func TwoFilesAtRootTwoInSubdir(root *Path) error {
 		return err
 	}
 	subdir := root.Join("subdir")
-	if err := subdir.Mkdir(0o777); err != nil {
+	if err := subdir.Mkdir(); err != nil {
 		return err
 	}
 	return NFiles(subdir, 2)

--- a/vars.go
+++ b/vars.go
@@ -1,0 +1,9 @@
+package pathlib
+
+import "os"
+
+// DefaultFileMode is the file mode that will be applied to new pathlib files
+var DefaultFileMode = os.FileMode(0o644)
+
+// DefaultDirMode is the default mode that will be applied to new directories
+var DefaultDirMode = os.FileMode(0o755)

--- a/walk_test.go
+++ b/walk_test.go
@@ -139,7 +139,7 @@ func (w *WalkSuiteAll) TestPassesQuerySpecification() {
 
 	// Directory tests
 	dir := w.root.Join("subdir")
-	require.NoError(w.T(), dir.MkdirAll(0o777))
+	require.NoError(w.T(), dir.MkdirAll())
 
 	stat, err = dir.Stat()
 	require.NoError(w.T(), err)


### PR DESCRIPTION
This fixes #14. We are moving towards a model where all new pathlib
objects will use the Default*Mode variables that can be changed by users
to set the mode bits used when creating dirs/files.