### PR TITLE
Changing IsDir/IsFile/IsSymlink

### DIFF
--- a/path.go
+++ b/path.go
@@ -211,10 +211,10 @@ func (p *Path) IsDir() (bool, error) {
 	return afero.IsDir(p.Fs(), p.String())
 }
 
-// IsDir returns whether or not the os.FileInfo object represents a
+// IsDir returns whether or not the os.FileMode object represents a
 // directory.
-func IsDir(fileInfo os.FileInfo) bool {
-	return fileInfo.IsDir()
+func IsDir(mode os.FileMode) bool {
+	return mode.IsDir()
 }
 
 // IsEmpty checks if a given file or directory is empty.
@@ -484,13 +484,13 @@ func (p *Path) IsFile() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return IsFile(fileInfo), nil
+	return IsFile(fileInfo.Mode()), nil
 }
 
 // IsFile returns whether or not the file described by the given
-// os.FileInfo is a regular file.
-func IsFile(fileInfo os.FileInfo) bool {
-	return fileInfo.Mode().IsRegular()
+// os.FileMode is a regular file.
+func IsFile(mode os.FileMode) bool {
+	return mode.IsRegular()
 }
 
 // IsSymlink returns true if the given path is a symlink.
@@ -500,13 +500,13 @@ func (p *Path) IsSymlink() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return IsSymlink(fileInfo), nil
+	return IsSymlink(fileInfo.Mode()), nil
 }
 
 // IsSymlink returns true if the file described by the given
-// os.FileInfo describes a symlink.
-func IsSymlink(fileInfo os.FileInfo) bool {
-	return fileInfo.Mode()&os.ModeSymlink != 0
+// os.FileMode describes a symlink.
+func IsSymlink(mode os.FileMode) bool {
+	return mode&os.ModeSymlink != 0
 }
 
 // DeepEquals returns whether or not the path pointed to by other

--- a/walk.go
+++ b/walk.go
@@ -144,7 +144,7 @@ func (w *Walk) walkDFS(walkFn WalkFunc, root *Path, currentDepth int) error {
 	if err := w.iterateImmediateChildren(root, func(child *Path, info os.FileInfo, encounteredErr error) error {
 		// Since we are doing depth-first, we have to first recurse through all the directories,
 		// and save all non-directory objects so we can defer handling at a later time.
-		if IsDir(info) {
+		if IsDir(info.Mode()) {
 			if err := w.walkDFS(walkFn, child, currentDepth+1); err != nil {
 				return err
 			}
@@ -220,7 +220,7 @@ func (w *Walk) iterateImmediateChildren(root *Path, algorithmFunction WalkFunc) 
 // the os.FileInfo passes all of the query specifications listed in
 // the walk options.
 func (w *Walk) passesQuerySpecification(info os.FileInfo) (bool, error) {
-	if IsFile(info) {
+	if IsFile(info.Mode()) {
 		if !w.Opts.VisitFiles {
 			return false, nil
 		}
@@ -229,9 +229,9 @@ func (w *Walk) passesQuerySpecification(info os.FileInfo) (bool, error) {
 			!w.Opts.MeetsMaximumSize(info.Size()) {
 			return false, nil
 		}
-	} else if IsDir(info) && !w.Opts.VisitDirs {
+	} else if IsDir(info.Mode()) && !w.Opts.VisitDirs {
 		return false, nil
-	} else if IsSymlink(info) && !w.Opts.VisitSymlinks {
+	} else if IsSymlink(info.Mode()) && !w.Opts.VisitSymlinks {
 		return false, nil
 	}
 
@@ -244,7 +244,7 @@ func (w *Walk) walkBasic(walkFn WalkFunc, root *Path, currentDepth int) error {
 	}
 
 	err := w.iterateImmediateChildren(root, func(child *Path, info os.FileInfo, encounteredErr error) error {
-		if IsDir(info) {
+		if IsDir(info.Mode()) {
 			if err := w.walkBasic(walkFn, child, currentDepth+1); err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes #28

These functions only need to know the file mode, not the whole
os.FileInfo object.