### PR TITLE
Add ErrWalkSkipSubtree

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -14,6 +14,16 @@ var (
 	ErrLstatNotPossible = fmt.Errorf("lstat is not possible")
 	// ErrRelativeTo indicates that we could not make one path relative to another
 	ErrRelativeTo = fmt.Errorf("failed to make path relative to other")
-	// ErrStopWalk indicates to the Walk function that the walk should be aborted
-	ErrStopWalk = fmt.Errorf("stop filesystem walk")
+	ErrWalk       = fmt.Errorf("walk control")
+	// ErrSkipSubtree indicates to the walk function that the current subtree of
+	// directories should be skipped. It's recommended to only use this error
+	// with the AlgorithmPreOrderDepthFirst algorithm, as many other walk algorithms
+	// will not respect this error due to the nature of the ordering in which the
+	// algorithms visit each node of the filesystem tree.
+	ErrWalkSkipSubtree = fmt.Errorf("skip subtree: %w", ErrWalk)
+	// ErrStopWalk indicates to the Walk function that the walk should be aborted.
+	// DEPRECATED: Use ErrWalkStop
+	ErrStopWalk = ErrWalkStop
+	// ErrWalkStop indicates to the Walk function that the walk should be aborted.
+	ErrWalkStop = fmt.Errorf("stop filesystem walk: %w", ErrWalk)
 )


### PR DESCRIPTION
- [x] Add new error type that allows walker to skip certain subtrees
- [x] Add more extensive tests for walk ordering 
- [x] Add test for ErrWalkSkipSubtree for each algorithm type