### PR TITLE
Fix bug with ErrSkipSubtree at root

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -13,17 +13,17 @@ var (
 	// ErrLstatNotPossible specifies that the filesystem does not support lstat-ing
 	ErrLstatNotPossible = fmt.Errorf("lstat is not possible")
 	// ErrRelativeTo indicates that we could not make one path relative to another
-	ErrRelativeTo = fmt.Errorf("failed to make path relative to other")
-	ErrWalk       = fmt.Errorf("walk control")
+	ErrRelativeTo  = fmt.Errorf("failed to make path relative to other")
+	errWalkControl = fmt.Errorf("walk control")
 	// ErrSkipSubtree indicates to the walk function that the current subtree of
 	// directories should be skipped. It's recommended to only use this error
 	// with the AlgorithmPreOrderDepthFirst algorithm, as many other walk algorithms
 	// will not respect this error due to the nature of the ordering in which the
 	// algorithms visit each node of the filesystem tree.
-	ErrWalkSkipSubtree = fmt.Errorf("skip subtree: %w", ErrWalk)
+	ErrWalkSkipSubtree = fmt.Errorf("skip subtree: %w", errWalkControl)
 	// ErrStopWalk indicates to the Walk function that the walk should be aborted.
 	// DEPRECATED: Use ErrWalkStop
 	ErrStopWalk = ErrWalkStop
 	// ErrWalkStop indicates to the Walk function that the walk should be aborted.
-	ErrWalkStop = fmt.Errorf("stop filesystem walk: %w", ErrWalk)
+	ErrWalkStop = fmt.Errorf("stop filesystem walk: %w", errWalkControl)
 )

--- a/walk.go
+++ b/walk.go
@@ -395,7 +395,7 @@ func (w *Walk) Walk(walkFn WalkFunc) error {
 		return ErrInvalidAlgorithm
 	}
 	if err := algoFunc(walkFn, w.root, 0); err != nil {
-		if errors.Is(err, ErrStopWalk) {
+		if errors.Is(err, errWalkControl) {
 			return nil
 		}
 		return err

--- a/walk_test.go
+++ b/walk_test.go
@@ -441,6 +441,15 @@ func TestErrWalkSkipSubtree(t *testing.T) {
 				NewPath("subdir1").Join("subdir2", "foo.txt"),
 			},
 		},
+		{
+			"PreOrderDFS skip at root",
+			AlgorithmPreOrderDepthFirst,
+			nil,
+			NewPath("foo1.txt"),
+			[]*Path{
+				NewPath("foo1.txt"),
+			},
+		},
 		// Note about the PostOrderDFS case. ErrWalkSkipSubtree effectively
 		// has no meaning to this algorithm because in this case, the algorithm
 		// visits all children before visiting each node. Thus, our WalkFunc has
@@ -461,7 +470,7 @@ func TestErrWalkSkipSubtree(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			root := NewPath(t.TempDir())
-			walker, err := NewWalk(root, WalkAlgorithm(tt.algorithm), WalkVisitDirs(false), WalkSortChildren(true))
+			walker, err := NewWalk(root, WalkAlgorithm(tt.algorithm), WalkVisitDirs(false), WalkVisitFiles(true), WalkSortChildren(true))
 			require.NoError(t, err)
 
 			var tree []*Path


### PR DESCRIPTION
A bug existed where the ErrSkipSubtree error would be returned from `Walk()` if the error was specified at the root of the tree.