### PR TITLE
Add NewPathFromPath() method to modify path and preserve other path options

### DIFF
--- a/path.go
+++ b/path.go
@@ -614,11 +614,6 @@ func (p *Path) Glob(pattern string) ([]*Path, error) {
 	return Glob(p.Fs(), p.Join(pattern).String())
 }
 
-// // Glob returns all matches of pattern relative to this object's path.
-// func (p *Path) Glob(pattern string) ([]*Path, error) {
-// 	return Glob(p.Fs(), p.Join(pattern).String())
-// }
-
 // Clean returns a new object that is a lexically-cleaned
 // version of Path.
 func (p *Path) Clean() *Path {


### PR DESCRIPTION
Only modifies path while preserving the path options of the source path provided. 
Replaces NewPathAfero() in utility methods which silently replaced incoming separator with os defined separator